### PR TITLE
[fix]cart bug

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -9,13 +9,13 @@ class Public::CartItemsController < ApplicationController
 # ↓ ifが重なっちゃって汚くなってしまった！でもこれ以外のやり方が分かりません！！泣
 
   def create
-    cart_item = current_customer.cart_items.new(cart_item_params)
+    cart_item = CartItem.new(cart_item_params)
     if cart_item.amount == nil
       @item = cart_item.item_id
       redirect_to item_path(@item)
     else
-      if CartItem.find_by(item_id: params[:cart_item][:item_id]).present?
-        cart_item = CartItem.find_by(item_id: params[:cart_item][:item_id])
+      if CartItem.find_by(item_id: params[:cart_item][:item_id], customer_id: current_customer.id).present?
+        cart_item = CartItem.find_by(item_id: params[:cart_item][:item_id], customer_id: current_customer.id)
         cart_item.amount += params[:cart_item][:amount].to_i
         cart_item.update(amount: cart_item.amount)
         redirect_to cart_items_path, notice: "カートに商品を追加しました。"
@@ -47,7 +47,7 @@ class Public::CartItemsController < ApplicationController
   private
 
   def cart_item_params
-    params.require(:cart_item).permit(:item_id, :amount)
+    params.require(:cart_item).permit(:item_id, :amount, :customer_id)
   end
 
 end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -2,8 +2,8 @@ class CartItem < ApplicationRecord
 
   belongs_to :customer
   belongs_to :item
-
-  validates :amount, presence: true
+# 1～10に個数を制限
+  validates :amount, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 10}
 
   def subtotal
     item.with_tax_price * amount

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -15,7 +15,8 @@
             <p>数量を選択してください。</p>
             </div>
             <%= f.select :amount, *[1..10], {include_blank: "個数選択"}, class: 'custom-select' %>個<br>
-            <%= f.hidden_field :item_id, :value => @item.id %>
+            <%= f.hidden_field :item_id, value: @item.id %>
+            <%= f.hidden_field :customer_id, value: current_customer.id %>
             <%= f.submit "カートに入れる", class: "mt-4 btn btn-success" %>
           </div>
         <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -84,24 +84,6 @@ Item.find_or_create_by!(name: "りんご飴") do |item|
   item.is_active = "true"
 end
 
-#cart_itemデータ作成
-CartItem.find_or_create_by!(customer_id: "1") do |cart_item|
-  cart_item.customer_id = "1"
-  cart_item.item_id = "1"
-  cart_item.amount = "2"
-end
-
-CartItem.find_or_create_by!(customer_id: "1") do |cart_item|
-  cart_item.customer_id = "1"
-  cart_item.item_id = "2"
-  cart_item.amount = "1"
-end
-
-CartItem.find_or_create_by!(customer_id: "1") do |cart_item|
-  cart_item.customer_id = "1"
-  cart_item.item_id = "3"
-  cart_item.amount = "3"
-end
 
 #orderデータ作成
 #order_detailデータ作成


### PR DESCRIPTION
バグ修正しました

原因
カートがあるかどうかを判別する時(商品登録時)にカスタマーIDの識別が抜けていたため、一番乗りでカートを登録したカスタマーIDにカート情報が紐づけられてしまっていました。
簡単に言うと、一番乗りのユーザーのカートに登録してしまっている状況でした。なので追加しても表示されなかった。。逆に言うと、一番乗りのユーザーがカートに入れてない商品は他のユーザーがカートに入れることができる状態だったため、さっきの挙動をしてました

そしてついでに、amount(数量)のカラムに1～10個の制限を掛けました。これで10個以上買えなくなります。